### PR TITLE
Fix wrong Swift package URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import PackageDescription
 let package = Package(
     name: "MyPackage",
     dependencies: [
-        .Package(url: "https://github.com/attaswift/SipHash.git", from: "3.1.1")
+        .Package(url: "https://github.com/attaswift/Deque.git", from: "3.1.1")
     ]
 )
 ```


### PR DESCRIPTION
Fix wrong Swift package URL in README.md